### PR TITLE
Change HEAD to original after execution instead of staying on INPUT_BASEREF

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,8 @@ if [ "$INPUT_PROJECT" == ":" ]; then
   INPUT_PROJECT=""
 fi
 
+current_head=$(git rev-parse HEAD)
+
 ./gradlew $ADDITIONAL_GRADLE_ARGUMENTS projects
 ./gradlew $ADDITIONAL_GRADLE_ARGUMENTS "$INPUT_PROJECT":dependencies --configuration "$INPUT_CONFIGURATION" >new_diff.txt
 git fetch --force origin "$INPUT_BASEREF":"$INPUT_BASEREF" --no-tags
@@ -20,3 +22,5 @@ delimiter=$(openssl rand -hex 20)
 echo "text-diff<<$delimiter" >> $GITHUB_OUTPUT
 echo "$diff" >> $GITHUB_OUTPUT
 echo "$delimiter" >> $GITHUB_OUTPUT
+
+git checkout "$current_head"


### PR DESCRIPTION
Our team performs lint checks following this action and summarizes the findings in comments on GitHub. Currently, the branch remains on INPUT_BASEREF after execution, which is an implicit behavior. 

For better clarity and workflow consistency, we propose reverting back to the original HEAD once the action completes. This change ensures subsequent tasks run on the appropriate context of the original commit.
