### PR TITLE
Save the full diff as a file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,12 +29,11 @@ current_head=$(git rev-parse HEAD)
 git fetch --force origin "$INPUT_BASEREF":"$INPUT_BASEREF" --no-tags
 git switch --force "$INPUT_BASEREF"
 ./gradlew $INPUT_ADDITIONAL_GRADLE_ARGUMENTS "$INPUT_PROJECT":dependencies --configuration "$INPUT_CONFIGURATION" >old_diff.txt
-
-diff=$(java -jar dependency-tree-diff.jar old_diff.txt new_diff.txt)
+java -jar dependency-tree-diff.jar old_diff.txt new_diff.txt >tree_diff.txt
 
 delimiter=$(openssl rand -hex 20)
 echo "text-diff<<$delimiter" >> $GITHUB_OUTPUT
-echo "$diff" >> $GITHUB_OUTPUT
+cat tree_diff.txt >> $GITHUB_OUTPUT
 echo "$delimiter" >> $GITHUB_OUTPUT
 
 git switch --detach "$current_head"


### PR DESCRIPTION
This is useful to be able to easily upload the inputs and the diff as an artifact.
We could do a manual diff, but it's simpler to do it here as it's already calculated.