### PR TITLE
Update Readme to follow setup-gradle action

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,9 +29,10 @@ jobs:
         distribution: 'temurin'
         java-version: 21
         
-    - uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: dependencies
+    - uses: gradle/actions/setup-gradle@v4
+
+    - name: Run dependencies
+      run: ./gradlew dependencies
 
     - id: dependency-diff
       name: Generate dependency diff


### PR DESCRIPTION
In this PR, I update Readme to follow `setup-gradle` action major update.

`setup-gradle` action v4 has released and the `arguments` parameter has removed.

- https://github.com/gradle/actions/releases/tag/v4.0.0

Instead  of `arguments` parameter, it is recommended to run gradle task directly. So I'd like to fix the Readme.